### PR TITLE
no Any::Moose; use Mouse;

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,6 +39,6 @@ auto_set_repository;
 
 test_requires 'Test::More' => '0.96';
 requires 'perl' => '5.008001';
-requires 'Any::Moose' => '0.18';
+requires 'Mouse' => '1.00';
 
 WriteAll;

--- a/lib/Sub/Rate.pm
+++ b/lib/Sub/Rate.pm
@@ -1,7 +1,7 @@
 package Sub::Rate;
 use strict;
 use warnings;
-use Any::Moose;
+use Mouse;
 use Carp;
 
 our $VERSION = '0.05';
@@ -32,7 +32,7 @@ has _default_func => (
     is => 'rw',
 );
 
-no Any::Moose;
+no Mouse;
 
 sub add {
     my ($self, $rate, $func) = @_;

--- a/lib/Sub/Rate/NoMaxRate.pm
+++ b/lib/Sub/Rate/NoMaxRate.pm
@@ -1,7 +1,7 @@
 package Sub::Rate::NoMaxRate;
 use strict;
 use warnings;
-use Any::Moose;
+use Mouse;
 
 use List::Util 'sum';
 
@@ -18,6 +18,8 @@ after clear => sub {
     my ($self) = @_;
     $self->max_rate(0);
 };
+
+no Mouse;
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
I hope you to merge another `no Any::Moose;` p-r too.

https://github.com/typester/GitDDL/pulls
https://github.com/typester/Test-RedisServer/pulls
