### PR TITLE
MANIFEST.SKIP: ignore MYMETA.*

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -15,3 +15,4 @@
 \.gitignore$
 ^tools/
 ^\.travis\.yml$
+^MYMETA\.


### PR DESCRIPTION
MYMETA.yml and MYMETA.json are bundled in the tarball of the 0.05 release. They are files that are only generated on the end-user machine during configure time, so they must be excluded.
